### PR TITLE
Fix bug in KMC

### DIFF
--- a/pynumtools/kmc/kinetic_monte_carlo.py
+++ b/pynumtools/kmc/kinetic_monte_carlo.py
@@ -93,8 +93,8 @@ class Conversion(Reaction):
         super(Conversion, self).__init__(rate, n_species, n_boxes, species_names)
         self.species_from = species_from
         self.species_to = species_to
-        self.stoichiometric_delta[self.species_from] = -1
-        self.stoichiometric_delta[self.species_to] = +1
+        self.stoichiometric_delta[self.species_from] -= 1
+        self.stoichiometric_delta[self.species_to] += 1
 
     def propensity(self, box_state, box_idx):
         return self.rate[box_idx] * box_state[self.species_from]
@@ -114,9 +114,9 @@ class Fusion(Reaction):
         self.species_from1 = species_from1
         self.species_from2 = species_from2
         self.species_to = species_to
-        self.stoichiometric_delta[self.species_from1] = -1
-        self.stoichiometric_delta[self.species_from2] = -1
-        self.stoichiometric_delta[self.species_to] = +1
+        self.stoichiometric_delta[self.species_from1] -= 1
+        self.stoichiometric_delta[self.species_from2] -= 1
+        self.stoichiometric_delta[self.species_to] += 1
 
     def propensity(self, box_state, box_idx):
         return self.rate[box_idx] * box_state[self.species_from1] * box_state[self.species_from2]
@@ -138,9 +138,9 @@ class Fission(Reaction):
         self.species_from = species_from
         self.species_to1 = species_to1
         self.species_to2 = species_to2
-        self.stoichiometric_delta[self.species_from] = -1
-        self.stoichiometric_delta[self.species_to1] = +1
-        self.stoichiometric_delta[self.species_to2] = +1
+        self.stoichiometric_delta[self.species_from] -= 1
+        self.stoichiometric_delta[self.species_to1] += 1
+        self.stoichiometric_delta[self.species_to2] += 1
 
     def propensity(self, box_state, box_idx):
         return self.rate[box_idx] * box_state[self.species_from]
@@ -160,7 +160,7 @@ class Decay(Reaction):
     def __init__(self, species_from, rate, n_species, n_boxes, species_names):
         super(Decay, self).__init__(rate, n_species, n_boxes, species_names)
         self.species_from = species_from
-        self.stoichiometric_delta[self.species_from] = -1
+        self.stoichiometric_delta[self.species_from] -= 1
 
     def propensity(self, box_state, box_idx):
         return self.rate[box_idx] * box_state[self.species_from]
@@ -178,7 +178,7 @@ class Creation(Reaction):
     def __init__(self, species_to, rate, n_species, n_boxes, species_names):
         super(Creation, self).__init__(rate, n_species, n_boxes, species_names)
         self.species_to = species_to
-        self.stoichiometric_delta[self.species_to] = +1
+        self.stoichiometric_delta[self.species_to] += 1
 
     def propensity(self, box_state, box_idx):
         return self.rate[box_idx]

--- a/pynumtools/kmc/test/test_kmc.py
+++ b/pynumtools/kmc/test/test_kmc.py
@@ -119,6 +119,16 @@ class TestKineticMonteCarlo(unittest.TestCase):
         # A or B (or both ) have a delta of 1 in box 0
         self.assertTrue(a_difference == 1 or b_difference == 1)
 
+    def test_educt_is_product(self):
+        system = kmc.ReactionDiffusionSystem([[[0.]],[[0.]]], 2, 1, [[1, 0]], species_names=["DA", "A"])
+        system.add_fission("DA", "DA", "A", np.array([0.1]))
+        system.simulate(20)
+        counts, times = system.convert_events_to_time_series2(0.001)
+        self.assertEqual(counts[0,0,0], 1, msg="initial state DA(0) = 1")
+        self.assertEqual(counts[0,0,1], 0, msg="initial state A(0) = 0")
+        self.assertEqual(counts[-1,0,0], 1, msg="final state DA(-1) = 1, DA is conserved")
+        self.assertEqual(counts[-1,0,1], 20, msg="final state A(-1) = 20, due to 20 events sampled")
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pynumtools/test/test_finite_differences.py
+++ b/pynumtools/test/test_finite_differences.py
@@ -7,7 +7,7 @@ from pynumtools.util import sliding_window
 
 class TestFiniteDifferences(unittest.TestCase):
     def test_first_derivative(self):
-        x0 = np.arange(0, 2.0 * np.pi, 0.05)
+        x0 = np.arange(0, 2.0 * np.pi, 0.01)
         xx = []
         for x in x0:
             if np.random.random() < .3:
@@ -28,7 +28,7 @@ class TestFiniteDifferences(unittest.TestCase):
         np.testing.assert_almost_equal(deriv, true_deriv, 6)
 
     def test_second_derivative(self):
-        x0 = np.arange(0, 2.0 * np.pi, 0.05)
+        x0 = np.arange(0, 2.0 * np.pi, 0.01)
         xx = []
         for x in x0:
             if np.random.random() < .3:


### PR DESCRIPTION
When educt is equal to a product, e.g. `A -> A + B`, A is consumed and created (delta=0), such that the number of As should be constant. This did not work, since only the creation of A was applied to the system state.